### PR TITLE
Fix: coerce tags and version to str to avoid Pydantic validation errors

### DIFF
--- a/yatta/models/change_log.py
+++ b/yatta/models/change_log.py
@@ -41,8 +41,8 @@ class Changelog(BaseModel):
 
     @field_validator("version", mode="before")
     @classmethod
-    def _coerce_version(cls, v):
-        return str(v) if v is not None else ""
+    def __coerce_version(cls, v: str | int) -> str:
+        return str(v)
 
     @field_validator("categories", mode="before")
     @classmethod

--- a/yatta/models/item.py
+++ b/yatta/models/item.py
@@ -126,9 +126,7 @@ class ItemDetail(BaseModel):
 
     @field_validator("tags", mode="before")
     @classmethod
-    def _coerce_tags(cls, v):
-        if v is None:
-            return []
+    def __coerce_tags(cls, v: list[str | int]) -> list[str]:
         return [str(tag) for tag in v]
 
     @field_validator("icon", mode="before")
@@ -167,9 +165,7 @@ class Item(BaseModel):
 
     @field_validator("tags", mode="before")
     @classmethod
-    def _coerce_tags(cls, v):
-        if v is None:
-            return []
+    def __coerce_tags(cls, v: list[str | int]) -> list[str]:
         return [str(tag) for tag in v]
 
     @field_validator("icon", mode="before")


### PR DESCRIPTION
This PR fixes a pydantic_core._pydantic_core.ValidationError caused when the Yatta API returns int values for fields defined as list[str] or str. The cases I've run into are tags in classes Item and ItemDetail, and version in class Changelog.

**Steps to reproduce:**
```
import asyncio
import yatta

async def main():
    async with yatta.YattaAPI() as client:
        items = await client.fetch_items()
        print(items)

asyncio.run(main())
```

**Result:**
```
ValidationError: 1 validation error for Item
tags.1
  Input should be a valid string [type=string_type, input_value=651, input_type=int]
```
  
The API may sometimes returns numeric IDs instead of strings:
- tags may contain integers instead of strings.
- version in changelogs may be returned as an integer.

Since the Pydantic models enforce strict typing (list[str], str), the parser raises a validation error.

**Fix:**
- Added @field_validator to tags in both Item and ItemDetail to coerce all values to strings.
- Added @field_validator to version in changelog models to coerce numeric versions to strings.

Same script now runs without the error shown earlier.